### PR TITLE
Move SyncWork from presentation to data module

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -55,4 +55,13 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
     implementation(libs.retrofit2.kotlin.coroutines.adapter)
+
+    // Hilt
+    implementation(libs.hilt.dagger.android)
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.dagger.compiler)
+    ksp(libs.hilt.compiler)
+
+    // WorkManager
+    implementation(libs.work.runtime.ktx)
 }

--- a/data/src/main/kotlin/com/aliasadi/data/workers/SyncWork.kt
+++ b/data/src/main/kotlin/com/aliasadi/data/workers/SyncWork.kt
@@ -1,4 +1,4 @@
-package com.aliasadi.clean.workers
+package com.aliasadi.data.workers
 
 import android.content.Context
 import android.util.Log
@@ -25,21 +25,23 @@ class SyncWork @AssistedInject constructor(
 
     override suspend fun doWork(): Result = withContext(dispatchers.io) {
         return@withContext if (movieRepository.sync()) {
-            Log.d("XXX", "SyncWork: doWork() called -> success")
+            Log.d(LOG_TAG, "SyncWork: doWork() called -> success")
             Result.success()
         } else {
             val lastAttempt = runAttemptCount >= SYNC_WORK_MAX_ATTEMPTS
             if (lastAttempt) {
-                Log.d("XXX", "SyncWork: doWork() called -> failure")
+                Log.d(LOG_TAG, "SyncWork: doWork() called -> failure")
                 Result.failure()
             } else {
-                Log.d("XXX", "SyncWork: doWork() called -> retry")
+                Log.d(LOG_TAG, "SyncWork: doWork() called -> retry")
                 Result.retry()
             }
         }
     }
 
     companion object {
+        const val LOG_TAG = "SyncWork"
+
         fun getOneTimeWorkRequest() = OneTimeWorkRequestBuilder<SyncWork>()
             .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
             .build()

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -99,9 +99,6 @@ dependencies {
     // Paging
     implementation(libs.paging.compose)
 
-    // WorkManager
-    implementation(libs.work.runtime.ktx)
-
     // Compose
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/presentation/src/main/kotlin/com/aliasadi/clean/App.kt
+++ b/presentation/src/main/kotlin/com/aliasadi/clean/App.kt
@@ -11,7 +11,7 @@ import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import coil.request.CachePolicy
 import coil.util.DebugLogger
-import com.aliasadi.clean.workers.SyncWork
+import com.aliasadi.data.workers.SyncWork
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 


### PR DESCRIPTION
The SyncWork class, responsible for background data synchronization, has been relocated from the `presentation` module to the `data` module. This change improves the separation of concerns by placing data-related operations within the appropriate module.

Key changes:
- Moved `SyncWork.kt` to `data/src/main/kotlin/com/aliasadi/data/workers/`.
- Added a `LOG_TAG` constant in `SyncWork` for consistent logging.
- Removed WorkManager dependency from `presentation/build.gradle.kts`.
- Added WorkManager and Hilt dependencies to `data/build.gradle.kts` to support `SyncWork` and its Hilt injection.